### PR TITLE
Bump golang to 1.19

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.47.2
+          version: v1.49.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
       - run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.0 as builder
 
 ARG GOARCH=''
 ARG GITHUB_PAT=''

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onmetal/poollet
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
# Proposed Changes

- Bump golang to 1.19
- Bump GH workflows to use golang 1.19